### PR TITLE
Make setter of SentryEvent.Tags public

### DIFF
--- a/src/app/SharpRaven/Data/SentryEvent.cs
+++ b/src/app/SharpRaven/Data/SentryEvent.cs
@@ -126,7 +126,7 @@ namespace SharpRaven.Data
         public IDictionary<string, string> Tags
         {
             get { return this.tags; }
-            internal set { this.tags = value ?? new Dictionary<string, string>(); }
+            set { this.tags = value ?? new Dictionary<string, string>(); }
         }
     }
 }


### PR DESCRIPTION
To make it easier to include tags directly when constructing a new `SentryEvent`.

Related to PR #149.
